### PR TITLE
Make the versions configurable in the example docker-compose

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -20,7 +20,10 @@ services:
     restart: always
 
   jicofo:
-    build: ../jicofo
+    build:
+      context: ../jicofo
+      args:
+        JICOFO_VERSION: "403"
     container_name: jicofo
     image: jicofo
     volumes:
@@ -41,7 +44,7 @@ services:
     build: ../jvb/debian
     container_name: jvb
     image: jvb
-    ports: 
+    ports:
       - 4443:4443
       - 10000-10100/udp
     volumes:
@@ -61,7 +64,10 @@ services:
     restart: always
 
   jitsi-meet:
-    build: ../jitsi-meet
+    build:
+      context: ../jitsi-meet
+      args:
+        JITSIMEET_VERSION: "2957"
     container_name: jitsi-meet
     image: jitsi-meet
     volumes:

--- a/jicofo/Dockerfile
+++ b/jicofo/Dockerfile
@@ -1,9 +1,12 @@
 FROM tiredofit/alpine:3.7
 LABEL maintainer="Dave Conroy <dave at tiredofit dot ca>"
 
+ARG JICOFO_VERSION
+
 ### Set Environment Variables
-  ENV ENABLE_SMTP=FALSE \
-      JICOFO_VERSION=403
+ENV ENABLE_SMTP=FALSE
+ENV JICOFO_VERSION=${JICOFO_VERSION:-403}
+
 
 ### Add User
   RUN adduser -h /usr/share/jicofo -D -g "Jitsi Conference Focus" -u 2500 jicofo && \

--- a/jitsi-meet/Dockerfile
+++ b/jitsi-meet/Dockerfile
@@ -1,9 +1,11 @@
 FROM tiredofit/nodejs:8-latest
 LABEL maintainer="Dave Conroy <dave at tiredofit dot ca>"
 
+ARG JITSIMEET_VERSION
+
 ### Set Environment Variables
-ENV ENABLE_SMTP=FALSE \
-    JITSIMEET_VERSION=2957
+ENV ENABLE_SMTP=FALSE
+ENV JITSIMEET_VERSION=${JITSIMEET_VERSION:-2957}
 
 ### Add User
   RUN set -x ; \


### PR DESCRIPTION
What does this PR do?

- Makes the versions configurable at the docker build step from
within the `example/docker-compose.yaml` file

Why is this PR needed?

- To get more control over versioning without modifying the Dockerfile directly every time.